### PR TITLE
プロフィール編集機能のエラー修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -85,8 +85,8 @@ class ProfilesController < ApplicationController
     end 
   end
 
-  def user_confirmation
-    unless current_user.id === @profile.user_id
+  def confirmation_user
+    unless current_user.id === @user.id
       redirect_to root_path
     end
   end


### PR DESCRIPTION
## What
プロフィール編集のエラー修正

## Why
プロフィール編集の際に、現在のユーザーのidとプロフィールが保持するuser_idが一致するか確認するメソッドの名前を間違えて記載していたため、修正。